### PR TITLE
NEOS parsing update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Add `xmlrpc-client-1.1.1.jar` file to `javaclasspath`
 Add SDPA-GMP to YALMIP by running
 
     >> install_sdpa_gmp_neos 
+    
+The installer will ask for a valid email address in order to use the NEOS XML-RPC interface
 
 **Note:** please ignore any compilation warnings that might be displayed.
 

--- a/callsdpagmp_neos.m
+++ b/callsdpagmp_neos.m
@@ -200,6 +200,11 @@ function xml_string = build_xml_string(sdpa_file,param_sdpa,precision)
 % XML header
 xml_string = sprintf('<document>\n<category>%s</category>\n<solver>%s</solver>\n<inputType>%s</inputType>\n','sdp','SDPA','SPARSE_SDPA');
 
+% Add email
+email = fileread('neos_email.dat');
+insert = sprintf('<email> %s </email>',email);
+xml_string = strcat(xml_string,insert);
+
 % File in sparse SDPA format
 dat = fileread(sdpa_file);
 insert = sprintf('<dat><![CDATA[%s]]></dat>\n',dat);

--- a/install_sdpa_gmp_neos.m
+++ b/install_sdpa_gmp_neos.m
@@ -77,6 +77,16 @@ if ~success
     error('Could not copy callsdpagmp_neos.m to the correct location.')
 end
 
+
+% ----------------------------------------------------------------------- %
+% CREATE EMAIL FILE IN UTILS PATH
+% ----------------------------------------------------------------------- %
+fid = fopen([pwd,filesep,'utils',filesep,'neos_email.dat'],'w'); 
+email = input('Insert email for NEOS results: ','s');
+fprintf(fid,'%s',email);
+fclose(fid);
+
+
 % ----------------------------------------------------------------------- %
 % ADD UTILS TO MATLAB PATH
 % ----------------------------------------------------------------------- %

--- a/utils/NeosSDPAInterface.m
+++ b/utils/NeosSDPAInterface.m
@@ -39,7 +39,7 @@ classdef NeosSDPAInterface
             % Query the webpage for the results
             url = sprintf('https://www.neos-server.org/neos/jobs/%d/%d.html', job - mod(job, 10000), job);
             result_page = urlread(url);
-            result = regexp(result_page, '(?<=<PRE>).*(?=<\/PRE>)', 'match');       
+            result = regexp(result_page, '(?<=<pre>).*(?=<\/pre>)', 'match');       
             
             % Open file
             fid=fopen(filename, 'w');


### PR DESCRIPTION
NEOS now requires an email for the XML-RPC interface. The installer will ask for an email address to use for NEOS and it will use that email in requests. It creates a file called 'neos_email.dat' containing the email in the utils folder.

The NEOS result page also has changed. It now uses lowercase 'pre' instead of an uppercase 'PRE'. The regex was updated accordingly.